### PR TITLE
Add warning to config.php about dropping the named database

### DIFF
--- a/config.php
+++ b/config.php
@@ -36,6 +36,7 @@ return [
         ['30000', '10FFFF'],
     ],
     // Name of the working database to use for processing
+    // WARNING: This database will be dropped, and recreated each time. Don't dont use an existing database!
     'dbname' => 'my_collation_db',
     // Name of the working table to use for processing
     'tablename' => 'my_table',


### PR DESCRIPTION
The fact that the script drops the database should be noted. I've just been bitten by this, as it dropped a real database, in no way expected to clear the database.